### PR TITLE
Update README with development workflow details

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ Built with **HTML/CSS/JS**, powered by **local JSON + sprites**, and completely 
 ---
 
 ## ✨ Features
-- 🎤 **Voice recognition** (Web Speech API) — say a Pokémon’s name to instantly fetch its info. (Not avaialble in desktop build) 
+- 🎤 **Voice recognition** (Web Speech API) — say a Pokémon’s name to instantly fetch its info. (Not available in the desktop build)
 - ⌨️ **Fallback search** — type or pick from a dropdown.  
 - 🧩 **Type matchups** — see weaknesses, resistances, and immunities using a Gen-9 style type chart.  
 - 🖼 **Sprites included offline** — official artwork and in-game sprites packaged locally.  
@@ -39,6 +39,43 @@ Then open:
 
 👉 http://localhost:8000/index.html
 
+> 💡 Tip: Voice input depends on the browser’s Web Speech API. Use the hosted version in Chrome or Edge for microphone support; locally served builds fall back to text search.
+
+## 🧱 Repository Overview
+
+- `index.html`, `sprites/`, `data/` — the offline web app.
+- `scripts/` — helper utilities for rebuilding the dataset and sprite library.
+- `make_icon.py` and `icon.png` — tooling/assets for the desktop Electron wrapper.
+- `demoPNG.png`, `demo-gif.gif` — promotional screenshots used in the README.
+
+## 🛠️ Development Notes
+
+All tooling is Python-based and works with Python 3.9+ (no external dependencies required).
+
+### Refreshing the Pokémon dataset
+
+The app reads from `data/pokemon.min.json`. To refresh the data (all Pokémon, forms, and available moves straight from the latest Game Master), run:
+
+```bash
+python scripts/build_pokemon_json.py
+```
+
+The script downloads the current Game Master from the PokeMiners project, expands every form (regional, costume, mega, shadow, etc.), and writes a compact JSON file ready for offline use. You can also point it at a local Game Master dump:
+
+```bash
+python scripts/build_pokemon_json.py ~/Downloads/latest.json data/pokemon.min.json
+```
+
+### Updating sprites
+
+To refresh the bundled artwork, clone [`PokeAPI/sprites`](https://github.com/PokeAPI/sprites) and run:
+
+```bash
+python scripts/collect_sprites.py /path/to/PokeAPI/sprites ./sprites
+```
+
+The helper copies both the high-resolution official artwork and fallback front sprites into the `sprites/` directory, renaming them to match the Pokédex numbering used by the app.
+
 ## 🖥️ Download
 
 - [Installer (recommended)](https://github.com/roryMansell/po-go-battle-assistant/releases/latest/download/Voice.Pokedex.Setup.1.0.0.exe)
@@ -51,16 +88,6 @@ Frontend: HTML, CSS, JavaScript (interactive UI, offline data handling, voice in
 Data prep: Python (scripts for JSON + sprite processing)
 
 Desktop packaging: Electron (Node.js ecosystem)
-
-## 📦 Updating the Pokémon GO dataset
-
-The app reads from `data/pokemon.min.json`. To refresh the data (all Pokémon, forms, and available moves straight from the latest Game Master), run:
-
-```bash
-python scripts/build_pokemon_json.py
-```
-
-The script downloads the current Game Master from the PokeMiners project, expands every form (regional, costume, mega, shadow, etc.), and writes a compact JSON file ready for offline use.
 
 ## 📜 License
 


### PR DESCRIPTION
## Summary
- clarify README voice recognition note and add repository overview
- document dataset and sprite refresh workflows for maintainers
- reorganize download and technology sections for easier scanning

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cd3e931f88832a868ef554a2e7c1e9